### PR TITLE
Fix the way we were getting the reducer name for reducer cache

### DIFF
--- a/src/spacetimedb_sdk/client_cache.py
+++ b/src/spacetimedb_sdk/client_cache.py
@@ -1,8 +1,10 @@
 import importlib
 import pkgutil
 
+
 def snake_to_camel(snake_case_string):
-    return snake_case_string.replace('_', ' ').title().replace(' ','')    
+    return snake_case_string.replace("_", " ").title().replace(" ", "")
+
 
 class TableCache:
     def __init__(self, table_class):
@@ -27,26 +29,28 @@ class TableCache:
     def get_entry(self, key):
         if key in self.entries:
             return self.entries[key]
-        
+
     def values(self):
         return self.entries.values()
 
 
 class ClientCache:
     def __init__(self, autogen_package):
-        
         self.tables = {}
         self.reducer_cache = {}
 
-        for importer, module_name, is_package in pkgutil.iter_modules(autogen_package.__path__):
+        for importer, module_name, is_package in pkgutil.iter_modules(
+            autogen_package.__path__
+        ):
             if not is_package:
                 module = importlib.import_module(
-                    f"{autogen_package.__name__}.{module_name}")
+                    f"{autogen_package.__name__}.{module_name}"
+                )
 
                 # check if its a reducer
                 if module_name.endswith("_reducer"):
-                    reducer_name = module_name[:-len("_reducer")]
-                    args_class = getattr(module,"_decode_args")
+                    reducer_name = getattr(module, "reducer_name")
+                    args_class = getattr(module, "_decode_args")
                     self.reducer_cache[reducer_name] = args_class
                 else:
                     # Assuming table class name is the same as the module name
@@ -56,11 +60,11 @@ class ClientCache:
                         table_class = getattr(module, table_class_name)
 
                         # Check for a special property, e.g. 'is_table_class'
-                        if getattr(table_class, 'is_table_class', False):
+                        if getattr(table_class, "is_table_class", False):
                             self.tables[table_class_name] = TableCache(table_class)
 
     def get_table_cache(self, table_name):
-        return self.tables[table_name]            
+        return self.tables[table_name]
 
     def decode(self, table_name, value):
         if not table_name in self.tables:
@@ -94,5 +98,5 @@ class ClientCache:
         if not table_name in self.tables:
             print(f"[get_entry] Error, table not found. ({table_name})")
             return
-        
+
         return self.tables[table_name].get_entry(key)

--- a/src/spacetimedb_sdk/spacetimedb_client.py
+++ b/src/spacetimedb_sdk/spacetimedb_client.py
@@ -110,6 +110,10 @@ class _SubscriptionUpdateMessage(_ClientApiMessage):
 
 
 class ReducerEvent:
+    """
+    This class contains the information about a reducer event to be passed to row update callbacks.
+    """
+
     def __init__(self, caller_identity, reducer_name, status, message, args):
         self.caller_identity = caller_identity
         self.reducer_name = reducer_name


### PR DESCRIPTION
## Description of Changes
*Describe what has been changed, any new features or bug fixes*

The previous way of getting the reducer name only worked if the reducer name was camel case. This new method will work for C# style reducer names with camel case

## API

 - [ ] This is an API breaking change to the SDK

*If the API is breaking, please state below what will break*


## Requires SpacetimeDB PRs
*List any PRs here that are required for this SDK change to work*

Relies on STDB PR: https://github.com/clockworklabs/SpacetimeDB/pull/166
