### PR TITLE
Remove SSL Enabled parameter to connect and change host to spacetimedb_uri

### DIFF
--- a/examples/quickstart/client/main.py
+++ b/examples/quickstart/client/main.py
@@ -19,9 +19,8 @@ def run_client(spacetime_client):
     asyncio.run(
         spacetime_client.run(
             local_config.get_string("auth_token"),
-            "localhost:3000",
-            "chat",
-            False,
+            "http://localhost:3000",
+            "chatqs",
             on_connect,
             ["SELECT * FROM User", "SELECT * FROM Message"],
         )

--- a/examples/quickstart/client/module_bindings/send_message_reducer.py
+++ b/examples/quickstart/client/module_bindings/send_message_reducer.py
@@ -7,6 +7,8 @@ from spacetimedb_sdk.spacetimedb_client import SpacetimeDBClient
 from spacetimedb_sdk.spacetimedb_client import Identity
 
 
+reducer_name = "send_message"
+
 def send_message(text: str):
 	text = text
 	SpacetimeDBClient.instance._reducer_call("send_message", text)

--- a/examples/quickstart/client/module_bindings/set_name_reducer.py
+++ b/examples/quickstart/client/module_bindings/set_name_reducer.py
@@ -7,6 +7,8 @@ from spacetimedb_sdk.spacetimedb_client import SpacetimeDBClient
 from spacetimedb_sdk.spacetimedb_client import Identity
 
 
+reducer_name = "set_name"
+
 def set_name(name: str):
 	name = name
 	SpacetimeDBClient.instance._reducer_call("set_name", name)

--- a/src/spacetimedb_sdk/spacetime_websocket_client.py
+++ b/src/spacetimedb_sdk/spacetime_websocket_client.py
@@ -5,7 +5,9 @@ import binascii
 
 
 class WebSocketClient:
-    def __init__(self, protocol, on_connect=None, on_close=None, on_error=None, on_message=None):
+    def __init__(
+        self, protocol, on_connect=None, on_close=None, on_error=None, on_message=None
+    ):
         self._on_connect = on_connect
         self._on_close = on_close
         self._on_error = on_error
@@ -14,15 +16,22 @@ class WebSocketClient:
         self.protocol = protocol
         self.ws = None
         self.message_thread = None
-        self.host = None
+        self.spacetimedb_uri = None
         self.name_or_address = None
         self.is_connected = False
 
-    def connect(self, auth, host, name_or_address, ssl_enabled):
-        protocol = "wss" if ssl_enabled else "ws"
-        url = f"{protocol}://{host}/database/subscribe/{name_or_address}"
+    def connect(self, auth, spacetimedb_uri, name_or_address):
+        if spacetimedb_uri[-1] == "/":
+            spacetimedb_uri = spacetimedb_uri[:-1]
 
-        self.host = host
+        if spacetimedb_uri[:5] == "https":
+            spacetimedb_uri = "wss" + spacetimedb_uri[5:]
+        elif spacetimedb_uri[:4] == "http":
+            spacetimedb_uri = "ws" + spacetimedb_uri[4:]
+
+        url = f"{spacetimedb_uri}/database/subscribe/{name_or_address}"
+
+        self.spacetimedb_uri = spacetimedb_uri
         self.name_or_address = name_or_address
 
         ws_header = None
@@ -35,13 +44,15 @@ class WebSocketClient:
         else:
             headers = None
 
-        self.ws = websocket.WebSocketApp(url,
-                                         on_open=self.on_open,
-                                         on_message=self.on_message,
-                                         on_error=self.on_error,
-                                         on_close=self.on_close, 
-                                         header=headers, 
-                                         subprotocols=[self.protocol])
+        self.ws = websocket.WebSocketApp(
+            url,
+            on_open=self.on_open,
+            on_message=self.on_message,
+            on_error=self.on_error,
+            on_close=self.on_close,
+            header=headers,
+            subprotocols=[self.protocol],
+        )
 
         self.message_thread = threading.Thread(target=self.ws.run_forever)
         self.message_thread.start()

--- a/src/spacetimedb_sdk/spacetime_websocket_client.py
+++ b/src/spacetimedb_sdk/spacetime_websocket_client.py
@@ -29,6 +29,9 @@ class WebSocketClient:
         elif spacetimedb_uri[:4] == "http":
             spacetimedb_uri = "ws" + spacetimedb_uri[4:]
 
+        if spacetimedb_uri[:5] != "ws://" and spacetimedb_uri[:6] != "wss://":
+            spacetimedb_uri = "ws://" + spacetimedb_uri
+
         url = f"{spacetimedb_uri}/database/subscribe/{name_or_address}"
 
         self.spacetimedb_uri = spacetimedb_uri

--- a/src/spacetimedb_sdk/spacetimedb_async_client.py
+++ b/src/spacetimedb_sdk/spacetimedb_async_client.py
@@ -133,9 +133,8 @@ class SpacetimeDBAsyncClient:
     async def run(
         self,
         auth_token,
-        host,
+        spacetimedb_uri,
         address_or_name,
-        ssl_enabled,
         on_connect,
         subscription_queries=[],
     ):
@@ -144,7 +143,7 @@ class SpacetimeDBAsyncClient:
 
         Args:
             auth_token : authentication token to use when connecting to the server
-            host : host name or IP address of the server
+            spacetimedb_uri : URI of the SpacetimeDB server (ex: https://testnet.spacetimedb.com)
             address_or_name : address or name of the module to connect to
             ssl_enabled : True to use SSL, False to not use SSL
             on_connect : function to call when the client connects to the server
@@ -155,7 +154,7 @@ class SpacetimeDBAsyncClient:
             self._on_async_loop_start()
 
         identity_result = await self.connect(
-            auth_token, host, address_or_name, ssl_enabled, subscription_queries
+            auth_token, spacetimedb_uri, address_or_name, subscription_queries
         )
 
         if on_connect is not None:
@@ -185,7 +184,11 @@ class SpacetimeDBAsyncClient:
         await self.close()
 
     async def connect(
-        self, auth_token, host, address_or_name, ssl_enabled, subscription_queries=[]
+        self,
+        auth_token,
+        spacetimedb_uri,
+        address_or_name,
+        subscription_queries=[],
     ):
         """
         Connect to the server.
@@ -194,7 +197,7 @@ class SpacetimeDBAsyncClient:
 
         Args:
             auth_token : authentication token to use when connecting to the server
-            host : host name or IP address of the server
+            spacetimedb_uri : URI of the SpacetimeDB server (ex: https://testnet.spacetimedb.com)
             address_or_name : address or name of the module to connect to
             ssl_enabled : True to use SSL, False to not use SSL
             subscription_queries : list of queries to subscribe to
@@ -219,9 +222,8 @@ class SpacetimeDBAsyncClient:
 
         self.client.connect(
             auth_token,
-            host,
+            spacetimedb_uri,
             address_or_name,
-            ssl_enabled,
             on_connect=None,
             on_error=on_error,
             on_disconnect=on_disconnect,

--- a/src/spacetimedb_sdk/spacetimedb_client.py
+++ b/src/spacetimedb_sdk/spacetimedb_client.py
@@ -215,9 +215,8 @@ class SpacetimeDBClient:
     def connect(
         self,
         auth_token,
-        host,
+        spacetimedb_uri,
         address_or_name,
-        ssl_enabled,
         on_connect,
         on_disconnect,
         on_identity,
@@ -238,9 +237,8 @@ class SpacetimeDBClient:
         # print("CONNECTING " + host + " " + address_or_name)
         self.wsc.connect(
             auth_token,
-            host,
+            spacetimedb_uri,
             address_or_name,
-            ssl_enabled,
         )
 
     def update(self):
@@ -592,8 +590,8 @@ class SpacetimeDBClient:
                         decode_func = self.client_cache.reducer_cache[
                             reducer_event.reducer_name
                         ]
-                        if reducer_event.status == "committed":
-                            args = decode_func(reducer_event.args)
+
+                        args = decode_func(reducer_event.args)
 
                         for reducer_callback in self._reducer_callbacks[
                             reducer_event.reducer_name


### PR DESCRIPTION
## Description of Changes

To make the SDKs more consistent, we are moving towards including the protocol in the `spacetimedb_uri` parameter to the connect function instead of providing a `host` and a bool for `sslenabled`

## API

 - [X] This is an API breaking change to the SDK

*If the API is breaking, please state below what will break*

The connect function call for existing projects need to be updated to remove the SSLEnabled argument and include the protocol in the `spacetimedb_uri` parameter 

## Requires SpacetimeDB PRs
*List any PRs here that are required for this SDK change to work*
