### PR TITLE
Need to decode args even if the reducer fails

### DIFF
--- a/src/spacetimedb_sdk/spacetimedb_client.py
+++ b/src/spacetimedb_sdk/spacetimedb_client.py
@@ -596,8 +596,8 @@ class SpacetimeDBClient:
                         decode_func = self.client_cache.reducer_cache[
                             reducer_event.reducer_name
                         ]
-                        if reducer_event.status == "committed":
-                            args = decode_func(reducer_event.args)
+
+                        args = decode_func(reducer_event.args)
 
                         for reducer_callback in self._reducer_callbacks[
                             reducer_event.reducer_name


### PR DESCRIPTION
## Description of Changes

This fixes an issue where a failed reducer will throw an exception in the client callback. This is because it was not adding the reducer args to the call so the number of "required args" was wrong.

## API

 - [ ] This is an API breaking change to the SDK

*If the API is breaking, please state below what will break*


## Requires SpacetimeDB PRs
*List any PRs here that are required for this SDK change to work*
